### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,6 @@ jobs:
           tag_name: ${{ steps.time.outputs.time }}
           target_commitish: main
           draft: false
-          generate_release_notes: true
     outputs:
       upload_url: ${{ steps.release.outputs.upload_url }}
       release_id: ${{ steps.release.outputs.id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ steps.time.outputs.time }}
           target_commitish: main
           draft: false
           generate_release_notes: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag_name: ${{ steps.time.outputs.time }}
           target_commitish: main
           draft: false
           generate_release_notes: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches:
       - main
+    tags:
+      - '*-*'
+    paths:
+      - 'boards/**'
+      - 'overlays/**'
+      - 'rootfs/**'
+      - 'scripts/**'
+
 jobs:
   prepare_release:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '*-*'
     paths:
       - 'boards/**'
       - 'overlays/**'


### PR DESCRIPTION
* Only run CI when build related files are modified.
* Disable automatically generated release note. They do not reflect the change between current and previous release.