### PR TITLE
change README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Enter Docker container...
 root@terra:~/debos-radxa#
 </pre>
 
+Change the size and permissions of /dev/shm
+
+<pre>
+root@terra:~/debos-radxa# mount -o remount,rw,nosuid,dev,exec,relatime,size=4G /dev/shm
+</pre>
+
 Launch `./build.sh` to get build options.
 
 <pre>

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,11 +4,15 @@ RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian/ testing main non-free 
 RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian/ testing-updates main non-free contrib" >> /etc/apt/sources.list
 RUN echo "deb http://mirrors.tuna.tsinghua.edu.cn/debian-security/ testing-security main non-free contrib" >> /etc/apt/sources.list
 
-RUN apt-get update -y && apt-get -y --allow-unauthenticated install debos xz-utils dosfstools
+RUN apt-get update -y 
+RUN apt-get install -y libterm-readkey-perl user-mode-linux libslirp-helper -y
+RUN apt-get -y install apt-utils xz-utils dosfstools --fix-missing
+
+RUN apt-get install debos -y --fix-missing
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends vim ssh ssh-import-id git tree \
-    debian-keyring gpgv network-manager host curl bmap-tools
+    debian-keyring gpgv network-manager host curl bmap-tools --fix-missing
 
 # add credentials on build
 ARG SSH_PRIVATE_KEY


### PR DESCRIPTION
Add one step to avoid some error caused by /dev/shm
I am using Ubuntu18.04, when I entered Docker container, the /dev/shm is mounted with noexec and only have 64M space.

I am not sure if this will happen to all the users.

I think this might have relation with partitions created when you install Ubuntu system.